### PR TITLE
Fixed deprecated name param in Syft API

### DIFF
--- a/federated-learning/duet_basics/Duet_Basics_Data_Owner.ipynb
+++ b/federated-learning/duet_basics/Duet_Basics_Data_Owner.ipynb
@@ -464,7 +464,7 @@
     "# You can automatically accept or deny requests, which is great for testing.\n",
     "# We have more advanced handlers coming soon.\n",
     "\n",
-    "duet.requests.add_handler(name=\"result_download\", action=\"accept\")"
+    "duet.requests.add_handler(action=\"accept\")"
    ]
   },
   {

--- a/federated-learning/duet_basics/Duet_Basics_Data_Scientist.ipynb
+++ b/federated-learning/duet_basics/Duet_Basics_Data_Scientist.ipynb
@@ -941,7 +941,6 @@
    "source": [
     "max_age_result = max_age_ptr.get(\n",
     "    request_block=True,\n",
-    "    name=\"result_download\",\n",
     "    reason=\"download the maximum age\",\n",
     "    timeout_secs=10,\n",
     ")\n",
@@ -966,7 +965,6 @@
    "source": [
     "min_age_result = min_age_ptr.get(\n",
     "    request_block=True,\n",
-    "    name=\"result_download\",\n",
     "    reason=\"download the minimum age\",\n",
     "    timeout_secs=10,\n",
     ")\n",
@@ -999,7 +997,7 @@
     }
    ],
    "source": [
-    "age_data = data_ptr.get(request_block=True, name=\"result_download\", delete_obj=False)\n",
+    "age_data = data_ptr.get(request_block=True, delete_obj=False)\n",
     "\n",
     "print(age_data)"
    ]


### PR DESCRIPTION
## Description
This fixes an issue where the `name` parameter is no longer available and breaks the notebook.

## Affected Dependencies
None

## How has this been tested?
Locally

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
