### PR TITLE
Fixed typo

### DIFF
--- a/cryptography/notebooks/MonoAlphabeticAttack_Exercise.ipynb
+++ b/cryptography/notebooks/MonoAlphabeticAttack_Exercise.ipynb
@@ -77,7 +77,7 @@
    "outputs": [],
    "source": [
     "# encrypt the message using monoalphabetic cipher and decrypt the resulting ciphertext\n",
-    "# print pobth on screen\n",
+    "# print both on screen\n",
     "\n",
     "message = \"this is a top secret message\"\n",
     "encrypted_message = None\n",
@@ -352,7 +352,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
Fixed typo "pobth" to "both" in cryptography exercise notebook.
