### PR TITLE
a potential typo fix

### DIFF
--- a/cryptography/notebooks/Prime_Numers.ipynb
+++ b/cryptography/notebooks/Prime_Numers.ipynb
@@ -328,7 +328,7 @@
     "\n",
     "where $q$ is an odd number and $k$ an integer. We can do this because we know that 2 is the only even prime number and therefore $p$-1 must be even if the prime number is larger than 2. For $p-1$ being even we can factor it as a product of $k$ times 2, times an even number.\n",
     "\n",
-    "Let $a$ be a number not divisible by $p$, then **one** of the following two conditions is true:\n",
+    "Let $a$ be any number not divisible by $p$, then **one** of the following two conditions is true:\n",
     "\n",
     "$$a^q-1=0\\textrm{ (mod p)}$$\n",
     "$$a^{cq}+1=0\\textrm{ (mod p)}$$\n",


### PR DESCRIPTION
## Description
In file "Prime_Numers.ipynb" cell 17, the author wrote: 

> Let $a$ be a number not divisible by $p$, then **one** of the following two conditions is true

 would it be better if we switch 

> Let $a$ be a number not divisible by $p$ 

by

>Let $a$ be any number not divisible by $p$" ?
