### PR TITLE
Improvement: Fixing deprecation warning for searchable parameter in duet

### DIFF
--- a/federated-learning/duet_fl/Duet_FL_Data_Owner_1.ipynb
+++ b/federated-learning/duet_fl/Duet_FL_Data_Owner_1.ipynb
@@ -93,7 +93,7 @@
     "data = data.tag(\"DO1 data\")\n",
     "data = data.describe(\"Dataset of 6 samples, 1 feature\")\n",
     "\n",
-    "data_ptr = data.send(duet, searchable=True)"
+    "data_ptr = data.send(duet, pointable=True)"
    ]
   },
   {
@@ -251,7 +251,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/federated-learning/duet_fl/Duet_FL_Data_Owner_2.ipynb
+++ b/federated-learning/duet_fl/Duet_FL_Data_Owner_2.ipynb
@@ -95,7 +95,7 @@
     "data = data.tag(\"DO2 data\")\n",
     "data = data.describe(\"Dataset of 5 samples, 1 feature\")\n",
     "\n",
-    "data_ptr = data.send(duet, searchable=True)"
+    "data_ptr = data.send(duet, pointable=True)"
    ]
   },
   {
@@ -252,7 +252,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/federated-learning/duet_iris_classifier/Duet_Iris_Data_Owner.ipynb
+++ b/federated-learning/duet_iris_classifier/Duet_Iris_Data_Owner.ipynb
@@ -306,8 +306,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_pointer = X.send(duet, searchable=True)\n",
-    "target_pointer = y.send(duet, searchable=True)"
+    "data_pointer = X.send(duet, pointable=True)\n",
+    "target_pointer = y.send(duet, pointable=True)"
    ]
   },
   {
@@ -452,7 +452,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description
The Course "Foundations of Private Computation" has used the searchable parameter multiple times in the initial lesson which is currently deprecated. Hence I just replaced them with pointable

## Dependencies changed
- Version changed to Python 3.8.10

## Tests
The repo itself doesn't really have tests but I wrote some of my own locally using unittest and everything worked.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
