### PR TITLE
Small fix in L3 Data Preparation

### DIFF
--- a/L3_DataPreparation.ipynb
+++ b/L3_DataPreparation.ipynb
@@ -1247,7 +1247,7 @@
     "import syft as sy\n",
     "\n",
     "# select all of Country 0's data\n",
-    "country0_data = raw_data[0, :]\n",
+    "country0_data = raw_data[:, 0]\n",
     "\n",
     "# Specify it to be a np.int32 dtype\n",
     "country0_data = country0_data.astype(np.int32)\n",


### PR DESCRIPTION
Country 0's data corresponds to the first column. Therefore, we should select raw_data[: , 0] instead of raw_data[0 , :]. Otherwise, we are selecting the first month (line) of every country.

## Description
Small fix.

## Affected Dependencies
None.

## How has this been tested?
- Tested the notebook.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
