### PR TITLE
Fix import path for DataSubject in L2 notebook

### DIFF
--- a/L2_Demo.ipynb
+++ b/L2_Demo.ipynb
@@ -302,7 +302,7 @@
    "source": [
     "import numpy as np\n",
     "import syft as sy\n",
-    "from syft.core.adp.entity import DataSubject\n",
+    "from syft.core.adp.data_subject import DataSubject\n",
     "\n",
     "raw_data = np.random.choice([0, 1], size=(10)).astype(np.int32)\n",
     "dataset = {}\n",


### PR DESCRIPTION
## Description
This change fixes DataSubject import path in L2 notebook.

## Affected Dependencies
N/A

## How has this been tested?
- Run the edited code block in Jupyter Lab on my local machine

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
